### PR TITLE
Project setup

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -352,6 +352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,7 +480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -484,7 +490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -508,7 +514,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -519,7 +525,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -611,7 +617,7 @@ checksum = "f2b99bf03862d7f545ebc28ddd33a665b50865f4dfd84031a393823879bd4c54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -738,7 +744,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -806,7 +812,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1063,7 +1069,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1142,7 +1148,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1321,6 +1327,19 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-traits",
+ "png",
 ]
 
 [[package]]
@@ -2040,7 +2059,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2087,7 +2106,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2553,7 +2572,7 @@ checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2586,7 +2605,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2637,7 +2656,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2858,9 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.59"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a6531ffc7b071655e4ce2e04bd464c4830bb585a61cabb96cf808f05172615a"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2959,6 +2978,7 @@ dependencies = [
  "gtk",
  "heck 0.4.1",
  "http",
+ "image",
  "jni",
  "libc",
  "log",
@@ -3030,7 +3050,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.59",
+ "syn 2.0.60",
  "tauri-utils",
  "thiserror",
  "time",
@@ -3048,7 +3068,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -3212,7 +3232,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3408,7 +3428,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3689,7 +3709,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -3723,7 +3743,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3834,7 +3854,7 @@ checksum = "ac1345798ecd8122468840bcdf1b95e5dc6d2206c5e4b0eafa078d061f59c9bc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3940,7 +3960,7 @@ checksum = "942ac266be9249c84ca862f0a164a39533dc2f6f33dc98ec89c8da99b82ea0bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3951,7 +3971,7 @@ checksum = "da33557140a288fae4e1d5f8873aaf9eb6613a9cf82c3e070223ff177f598b60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.59",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "2.0.0-beta", features = [] }
 
 [dependencies]
-tauri = { version = "2.0.0-beta", features = [] }
+tauri = { version = "2.0.0-beta", features = ["tray-icon"] }
 tauri-plugin-shell = "2.0.0-beta"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "2.0.0-beta", features = [] }
 
 [dependencies]
-tauri = { version = "2.0.0-beta", features = ["tray-icon"] }
+tauri = { version = "2.0.0-beta", features = ["tray-icon", "image-ico", "image-png"] }
 tauri-plugin-shell = "2.0.0-beta"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,16 +1,10 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-// Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
-#[tauri::command]
-fn greet(name: &str) -> String {
-    format!("Hello, {}! You've been greeted from Rust!", name)
-}
-
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,24 +1,56 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use tauri::{image::Image, tray::ClickType, Manager};
+use tauri::{image::Image, menu::{IsMenuItem, MenuBuilder, MenuItemBuilder}, tray::TrayIconBuilder, Manager};
 
 fn main() {
+
     tauri::Builder::default()
         .setup(|app| {
 
             let tray_icon  = Image::from_bytes(include_bytes!("../icons/icon.ico"))?;
-    
-            // Declared to show tray icon in some Linux distributions;
-            let menu_tray = tauri::menu::MenuBuilder::new(app).build()?;
-    
-            tauri::tray::TrayIconBuilder::new()
-                .icon(tray_icon)
-                .menu(&menu_tray)
-                .build(app)?;
-            Ok(())
 
-        })
+            // Declared to show tray icon in some Linux distributions;
+            #[cfg(target_os = "linux")] 
+            {
+                let item = MenuItemBuilder::new("Launch Kreck").build(app)?;
+                let menu_tray = MenuBuilder::new(app).item(&item).build()?;
+                
+                TrayIconBuilder::new()
+                    .icon(tray_icon)
+                    .menu(&menu_tray)
+                    .build(app)?;
+
+                app.on_menu_event(move |app, event| {
+                    if event.id() == item.id() {
+                        if let Some(webview_window) = app.get_webview_window("main") {
+                            let _ = webview_window.show();
+                            let _ = webview_window.set_focus();
+                        };
+                    }
+                })
+            }
+
+            #[cfg(not(target_os = "linux"))]
+            {
+                let menu_tray = MenuBuilder::new(app).build()?;
+
+                TrayIconBuilder::new()
+                    .icon(tray_icon)
+                    .menu(&menu_tray)
+                    .on_tray_icon_event(|tray, event| {
+                        
+                        if let Some(webview_window) = app.get_webview_window("main") {
+                            let _ = webview_window.show();
+                            let _ = webview_window.set_focus();
+                        }
+
+                    })
+                    .build(app)?;
+            }
+
+            Ok(())
+        }) 
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,7 +1,7 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use tauri::{image::Image, menu::{IsMenuItem, MenuBuilder, MenuItemBuilder}, tray::TrayIconBuilder, Manager};
+use tauri::{image::Image, menu::{MenuBuilder, MenuItemBuilder}, tray::TrayIconBuilder, Manager, WindowEvent};
 
 fn main() {
 
@@ -13,8 +13,15 @@ fn main() {
             // Declared to show tray icon in some Linux distributions;
             #[cfg(target_os = "linux")] 
             {
-                let item = MenuItemBuilder::new("Launch Kreck").build(app)?;
-                let menu_tray = MenuBuilder::new(app).item(&item).build()?;
+                let launch_kreck = MenuItemBuilder::new("Launch Kreck")
+                    .build(app)?;
+                let exit_kreck = MenuItemBuilder::new("Exit Kreck")
+                    .build(app)?;
+
+                let menu_tray = MenuBuilder::new(app)
+                    .item(&launch_kreck)
+                    .item(&exit_kreck)
+                    .build()?;
                 
                 TrayIconBuilder::new()
                     .icon(tray_icon)
@@ -22,11 +29,16 @@ fn main() {
                     .build(app)?;
 
                 app.on_menu_event(move |app, event| {
-                    if event.id() == item.id() {
+                    if event.id() == launch_kreck.id() {
                         if let Some(webview_window) = app.get_webview_window("main") {
                             let _ = webview_window.show();
                             let _ = webview_window.set_focus();
                         };
+                    } else if event.id() == exit_kreck.id() {
+                        if let Some(webview_window) = app.get_webview_window("main") {
+                            let _ = webview_window.close();
+                            let _ = webview_window.app_handle().exit(0);
+                        }
                     }
                 })
             }
@@ -39,18 +51,31 @@ fn main() {
                     .icon(tray_icon)
                     .menu(&menu_tray)
                     .on_tray_icon_event(|tray, event| {
-                        
                         if let Some(webview_window) = app.get_webview_window("main") {
                             let _ = webview_window.show();
                             let _ = webview_window.set_focus();
                         }
-
                     })
                     .build(app)?;
             }
 
             Ok(())
-        }) 
+        })
+        .on_window_event(|window, event|  {
+            match event {
+                window_event => {
+                    match window_event {
+                        WindowEvent::CloseRequested { api, .. } => {
+                            api.prevent_close();
+                            if let Some(webview_window) = window.get_webview_window("main") {
+                                webview_window.hide().unwrap();
+                            };
+                        }
+                        _ => ()
+                    }
+                }
+            };
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,10 +1,24 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+use tauri::{image::Image, tray::ClickType, Manager};
+
 fn main() {
     tauri::Builder::default()
-        .plugin(tauri_plugin_shell::init())
-        .invoke_handler(tauri::generate_handler![])
+        .setup(|app| {
+
+            let tray_icon  = Image::from_bytes(include_bytes!("../icons/icon.ico"))?;
+    
+            // Declared to show tray icon in some Linux distributions;
+            let menu_tray = tauri::menu::MenuBuilder::new(app).build()?;
+    
+            tauri::tray::TrayIconBuilder::new()
+                .icon(tray_icon)
+                .menu(&menu_tray)
+                .build(app)?;
+            Ok(())
+
+        })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "productName": "kreck",
   "version": "0.0.0",
-  "identifier": "com.tauri.dev",
+  "identifier": "com.kreck.dev",
   "build": {
     "frontendDist": "../src"
   },
@@ -28,5 +28,6 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
-  }
+  },
+  "plugins": {}
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,14 +8,14 @@
   "app": {
     "withGlobalTauri": true,
     "trayIcon": {
-      "iconPath": "./icons/icon.png",
+      "iconPath": "./icons/icon.ico",
       "iconAsTemplate": true
     },
     "windows": [
       {
         "title": "kreck",
-        "width": 800,
-        "height": 600
+        "width": 400,
+        "height": 300
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,9 @@
         "title": "kreck",
         "width": 400,
         "height": 300,
-        "skipTaskbar": true
+        "skipTaskbar": true,
+        "resizable": false,
+        "minimizable": false 
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,6 +7,10 @@
   },
   "app": {
     "withGlobalTauri": true,
+    "trayIcon": {
+      "iconPath": "./icons/icon.png",
+      "iconAsTemplate": true
+    },
     "windows": [
       {
         "title": "kreck",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -15,7 +15,8 @@
       {
         "title": "kreck",
         "width": 400,
-        "height": 300
+        "height": 300,
+        "skipTaskbar": true
       }
     ],
     "security": {


### PR DESCRIPTION
Add basic system tray support for Linux, Windows, and macOS, including a menu to open and close the running app. Additionally, implement a feature where clicking the close button on the title bar minimizes the app to the system tray. Ensure that the app does not appear in the OS taskbar, only in the system tray or as a regular window.

![image](https://github.com/Lucas-BRT/Kreck/assets/93885104/2bc426b0-b010-4277-84e6-44102cf0381f)
