### PR TITLE
fix: turn off native window shadow

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,6 +21,7 @@
         "closable": false,
         "hiddenTitle": true,
         "decorations": false,
+        "shadow": false,
         "transparent": true
       }
     ],


### PR DESCRIPTION
This fix removes the visible apparent border generated by the shadow that allow the see the real app window size by turning the shadow property to false

Before fix: 
![image](https://github.com/user-attachments/assets/fb8acf55-b5d4-4b19-8cb4-fae5c12ee3ae)

After fix:
![image](https://github.com/user-attachments/assets/74f6a57b-0b7c-4f1b-b65b-e727de815544)

